### PR TITLE
Allow duckweed and water mosaic to render behind the boat

### DIFF
--- a/src/main/resources/assets/nomansland/models/block/plants/duckweed.json
+++ b/src/main/resources/assets/nomansland/models/block/plants/duckweed.json
@@ -1,6 +1,6 @@
 {
 	"credit": "Made by Farcr",
-	"render_type": "minecraft:cutout",
+	"render_type": "minecraft:translucent",
 	"textures": {
 		"0": "nomansland:block/plants/duckweed",
 		"particle": "nomansland:block/plants/duckweed"

--- a/src/main/resources/assets/nomansland/models/block/plants/water_mosaic.json
+++ b/src/main/resources/assets/nomansland/models/block/plants/water_mosaic.json
@@ -1,6 +1,6 @@
 {
 	"credit": "Made by Farcr",
-	"render_type": "minecraft:cutout",
+	"render_type": "minecraft:translucent",
 	"textures": {
 		"0": "nomansland:block/plants/water_mosaic",
 		"particle": "nomansland:block/plants/water_mosaic"


### PR DESCRIPTION
Looks weird when using a boat through the swamps so created this to fix it
# Before:
![2025-04-08_11 03 32](https://github.com/user-attachments/assets/f6d4eb03-3ec3-4b59-9450-010b071285ad)
# After:
![2025-04-08_11 13 12](https://github.com/user-attachments/assets/681d9c66-7747-4d93-b586-40be5f48b76e)
