### PR TITLE
Change torch extinguishing / lighting to be less cumbersome

### DIFF
--- a/src/main/java/com/farcr/nomansland/NoMansLand.java
+++ b/src/main/java/com/farcr/nomansland/NoMansLand.java
@@ -7,6 +7,8 @@ import com.farcr.nomansland.common.integration.FDIntegration;
 import com.farcr.nomansland.common.integration.Mods;
 import com.farcr.nomansland.common.registry.*;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.farcr.nomansland.common.registry.blocks.NMLExtinguishables;
+import com.farcr.nomansland.common.registry.blocks.NMLFlammables;
 import com.farcr.nomansland.common.registry.entities.*;
 import com.farcr.nomansland.common.registry.items.NMLCreativeTabs;
 import com.farcr.nomansland.common.registry.items.NMLItems;
@@ -32,6 +34,7 @@ public class NoMansLand {
         NMLBlocks.BLOCKS.addAlias(NoMansLand.location("apple_fruit"), NoMansLand.location("apple"));
         NMLBlocks.BLOCKS.addAlias(NoMansLand.location("pear_fruit"), NoMansLand.location("pear"));
         NMLBlocks.BLOCKS.register(modEventBus);
+        NMLExtinguishables.EXTINGUISHABLES.register(modEventBus);
         NMLEntityDataSerializers.ENTITY_DATA_SERIALIZERS.register(modEventBus);
         NMLEntities.ENTITIES.register(modEventBus);
         NMLSensors.SENSORS.register(modEventBus);

--- a/src/main/java/com/farcr/nomansland/common/block/torches/ExtinguishableBlock.java
+++ b/src/main/java/com/farcr/nomansland/common/block/torches/ExtinguishableBlock.java
@@ -1,0 +1,6 @@
+package com.farcr.nomansland.common.block.torches;
+
+import net.minecraft.world.level.block.Block;
+
+public record ExtinguishableBlock(Block litBlock, Block extinguishedBlock) {
+}

--- a/src/main/java/com/farcr/nomansland/common/event/CommonSetupEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/CommonSetupEvents.java
@@ -12,6 +12,7 @@ import com.farcr.nomansland.common.integration.Mods;
 import com.farcr.nomansland.common.registry.NMLFluids;
 import com.farcr.nomansland.common.registry.NMLRegistries;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.farcr.nomansland.common.registry.blocks.NMLExtinguishables;
 import com.farcr.nomansland.common.registry.blocks.NMLFlammables;
 import com.farcr.nomansland.common.registry.entities.NMLEntities;
 import com.farcr.nomansland.common.world.generation.NMLBiomePlacements;
@@ -60,6 +61,8 @@ public class CommonSetupEvents {
         event.register(NMLRegistries.BOULDER_DECORATOR_TYPE);
         event.register(NMLRegistries.FALLEN_TREE_DECORATOR_TYPE);
         event.register(NMLRegistries.FOG_MODIFIERS);
+
+        event.register(NMLRegistries.EXTINGUISHABLE_BLOCKS);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -339,6 +339,10 @@ public class MiscellaneousEvents {
                     break;
                 }
             }
+
+            if (event.getExplosion().getDirectSourceEntity() instanceof ExplosiveEntity explosive && explosive.getOwner() instanceof ServerPlayer serverPlayer && state.is(Tags.Blocks.ORES)) {
+                NMLCriteriaTriggers.MINE_ORE_WITH_EXPLOSIVE.get().trigger(serverPlayer, pos);
+            }
         }
     }
 

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -10,6 +10,7 @@ import com.farcr.nomansland.common.registry.NMLRegistries;
 import com.farcr.nomansland.common.registry.NMLSounds;
 import com.farcr.nomansland.common.registry.NMLTags;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.farcr.nomansland.common.registry.blocks.NMLExtinguishables;
 import com.farcr.nomansland.common.registry.worldgen.NMLBiomes;
 import com.farcr.nomansland.common.registry.worldgen.NMLFeatures;
 import com.farcr.nomansland.common.saved_data.WardedSpacesData;
@@ -76,23 +77,22 @@ public class MiscellaneousEvents {
         boolean isExtinguishing = stack.is(ItemTags.SHOVELS) && NMLConfig.TORCH_EXTINGUISHING.get();
         boolean isLighting = stack.is(NMLTags.FIRESTARTERS);
         if (!player.isSpectator() && (isExtinguishing || isLighting)) {
-            for (Map.Entry<ResourceKey<ExtinguishableBlock>, ExtinguishableBlock> set : NMLRegistries.EXTINGUISHABLE_BLOCKS.entrySet()) {
-                ExtinguishableBlock value = set.getValue();
+            for (ExtinguishableBlock holder : NMLRegistries.EXTINGUISHABLE_BLOCKS) {
 
                 if (isExtinguishing) { //extinguishing block
-                    if (state.is(value.litBlock())) {
+                    if (state.is(holder.litBlock())) {
                         level.playSound(player, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 0.4F, 1.0F);
                         level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
-                        level.setBlockAndUpdate(pos, value.extinguishedBlock().withPropertiesOf(state));
+                        level.setBlockAndUpdate(pos, holder.extinguishedBlock().withPropertiesOf(state));
                         event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
                         event.setCanceled(true);
                         break;
                     }
                 } else { //lighting block
-                    if (state.is(value.extinguishedBlock())) {
+                    if (state.is(holder.extinguishedBlock())) {
                         level.playSound(player, pos, NMLSounds.TORCH_LIGHT.get(), SoundSource.BLOCKS, 1.0F, level.getRandom().nextFloat() * 0.4F + 0.8F);
                         level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
-                        level.setBlockAndUpdate(pos, value.litBlock().withPropertiesOf(state));
+                        level.setBlockAndUpdate(pos, holder.litBlock().withPropertiesOf(state));
                         event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
                         event.setCanceled(true);
                         break;
@@ -328,25 +328,18 @@ public class MiscellaneousEvents {
         Explosion explosion = event.getExplosion();
         Level level = event.getLevel();
 
-        event.getAffectedBlocks().forEach(pos -> {
+        for (BlockPos pos : event.getAffectedBlocks()) {
             BlockState state = level.getBlockState(pos);
-            if (state.getBlock() instanceof TorchBlock && !(state.getBlock() instanceof ExtinguishedTorchBlock)) {
-                level.gameEvent(explosion.getDirectSourceEntity(), GameEvent.BLOCK_CHANGE, pos);
-                level.playSound(null, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
 
-                if (state.is(Blocks.TORCH))
-                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.WALL_TORCH))
-                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_WALL_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.SOUL_TORCH))
-                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.SOUL_WALL_TORCH))
-                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_WALL_TORCH.get().withPropertiesOf(state), 11);
+            for (ExtinguishableBlock block : NMLRegistries.EXTINGUISHABLE_BLOCKS) {
+                if (state.is(block.litBlock())) {
+                    level.gameEvent(explosion.getDirectSourceEntity(), GameEvent.BLOCK_CHANGE, pos);
+                    level.setBlock(pos, block.extinguishedBlock().withPropertiesOf(state), 11);
+                    level.playSound(null, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
+                    break;
+                }
             }
-
-            if (event.getExplosion().getDirectSourceEntity() instanceof ExplosiveEntity explosive && explosive.getOwner() instanceof ServerPlayer serverPlayer && state.is(Tags.Blocks.ORES))
-                NMLCriteriaTriggers.MINE_ORE_WITH_EXPLOSIVE.get().trigger(serverPlayer, pos);
-        });
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -2,9 +2,11 @@ package com.farcr.nomansland.common.event;
 
 import com.farcr.nomansland.NMLConfig;
 import com.farcr.nomansland.NoMansLand;
+import com.farcr.nomansland.common.block.torches.ExtinguishableBlock;
 import com.farcr.nomansland.common.block.torches.ExtinguishedTorchBlock;
 import com.farcr.nomansland.common.entity.bombs.ExplosiveEntity;
 import com.farcr.nomansland.common.registry.NMLCriteriaTriggers;
+import com.farcr.nomansland.common.registry.NMLRegistries;
 import com.farcr.nomansland.common.registry.NMLSounds;
 import com.farcr.nomansland.common.registry.NMLTags;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
@@ -58,6 +60,7 @@ import java.util.Map;
 
 import static com.farcr.nomansland.common.block.FrostedGrassBlock.SNOWLOGGED;
 import static net.minecraft.world.level.block.SnowyDirtBlock.SNOWY;
+
 @SuppressWarnings("unused")
 @EventBusSubscriber(modid = NoMansLand.MODID)
 public class MiscellaneousEvents {
@@ -70,48 +73,31 @@ public class MiscellaneousEvents {
         Player player = event.getEntity();
         ItemStack stack = event.getItemStack();
 
-        List<Block> torches = List.of(
-                Blocks.TORCH,
-                Blocks.WALL_TORCH,
-                Blocks.SOUL_TORCH,
-                Blocks.SOUL_WALL_TORCH,
-                NMLBlocks.SCONCE_TORCH.get(),
-                NMLBlocks.SCONCE_WALL_TORCH.get(),
-                NMLBlocks.SCONCE_SOUL_TORCH.get(),
-                NMLBlocks.SCONCE_SOUL_WALL_TORCH.get()
-        );
+        boolean isExtinguishing = stack.is(ItemTags.SHOVELS) && NMLConfig.TORCH_EXTINGUISHING.get();
+        boolean isLighting = stack.is(NMLTags.FIRESTARTERS);
+        if (!player.isSpectator() && (isExtinguishing || isLighting)) {
+            for (Map.Entry<ResourceKey<ExtinguishableBlock>, ExtinguishableBlock> set : NMLRegistries.EXTINGUISHABLE_BLOCKS.entrySet()) {
+                ExtinguishableBlock value = set.getValue();
 
-        // Torch Extinguishing
-        if (torches.contains(state.getBlock()) && stack.is(ItemTags.SHOVELS) && !player.isSpectator() && NMLConfig.TORCH_EXTINGUISHING.get()) {
-            level.playSound(player, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 0.4F, 1.0F);
-
-            if (!level.isClientSide) {
-                stack.hurtAndBreak(1, player, stack.getEquipmentSlot());
-
-                BlockState extinguishedTorchState = ImmutableMap.ofEntries(
-                        Map.entry(Blocks.TORCH, NMLBlocks.EXTINGUISHED_TORCH),
-                        Map.entry(Blocks.WALL_TORCH, NMLBlocks.EXTINGUISHED_WALL_TORCH),
-                        Map.entry(Blocks.SOUL_TORCH, NMLBlocks.EXTINGUISHED_SOUL_TORCH),
-                        Map.entry(Blocks.SOUL_WALL_TORCH, NMLBlocks.EXTINGUISHED_SOUL_WALL_TORCH),
-                        Map.entry(NMLBlocks.SCONCE_TORCH.get(), NMLBlocks.EXTINGUISHED_SCONCE_TORCH),
-                        Map.entry(NMLBlocks.SCONCE_WALL_TORCH.get(), NMLBlocks.EXTINGUISHED_SCONCE_WALL_TORCH),
-                        Map.entry(NMLBlocks.SCONCE_SOUL_TORCH.get(), NMLBlocks.EXTINGUISHED_SCONCE_SOUL_TORCH),
-                        Map.entry(NMLBlocks.SCONCE_SOUL_WALL_TORCH.get(), NMLBlocks.EXTINGUISHED_SCONCE_SOUL_WALL_TORCH)
-                ).get(state.getBlock()).value().withPropertiesOf(state);
-
-                level.setBlockAndUpdate(pos, extinguishedTorchState);
-            }
-            event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
-            event.setCanceled(true);
-        }
-
-        if (state.hasProperty(BlockStateProperties.LIT)) {
-            if (!state.getValue(BlockStateProperties.LIT) && stack.is(NMLTags.FIRESTARTERS) && !stack.is(Items.FLINT_AND_STEEL)) {
-                level.playSound(player, pos, NMLSounds.TORCH_LIGHT.get(), SoundSource.BLOCKS, 1.0F, level.getRandom().nextFloat() * 0.4F + 0.8F);
-                level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
-                level.setBlockAndUpdate(pos, state.setValue(BlockStateProperties.LIT, true));
-                event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
-                event.setCanceled(true);
+                if (isExtinguishing) { //extinguishing block
+                    if (state.is(value.litBlock())) {
+                        level.playSound(player, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 0.4F, 1.0F);
+                        level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
+                        level.setBlockAndUpdate(pos, value.extinguishedBlock().withPropertiesOf(state));
+                        event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
+                        event.setCanceled(true);
+                        break;
+                    }
+                } else { //lighting block
+                    if (state.is(value.extinguishedBlock())) {
+                        level.playSound(player, pos, NMLSounds.TORCH_LIGHT.get(), SoundSource.BLOCKS, 1.0F, level.getRandom().nextFloat() * 0.4F + 0.8F);
+                        level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
+                        level.setBlockAndUpdate(pos, value.litBlock().withPropertiesOf(state));
+                        event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide()));
+                        event.setCanceled(true);
+                        break;
+                    }
+                }
             }
         }
 
@@ -160,7 +146,7 @@ public class MiscellaneousEvents {
             Direction playerDir = player.getDirection();
             RailShape railShape = null;
             if (state.getBlock() instanceof BaseRailBlock) {
-                railShape = state.getValue(((BaseRailBlock)state.getBlock()).getShapeProperty());
+                railShape = state.getValue(((BaseRailBlock) state.getBlock()).getShapeProperty());
             }
             if (railShape != null) {
                 int railCount = 0;
@@ -187,7 +173,7 @@ public class MiscellaneousEvents {
                         // Continue along the chain normally
                         RailShape offsetShape = null;
                         if (stateBase.getBlock() instanceof BaseRailBlock) {
-                            offsetShape = stateBase.getValue(((BaseRailBlock)stateBase.getBlock()).getShapeProperty());
+                            offsetShape = stateBase.getValue(((BaseRailBlock) stateBase.getBlock()).getShapeProperty());
                         }
 
                         if (offsetShape == null)
@@ -224,7 +210,7 @@ public class MiscellaneousEvents {
                             else if (playerDir != Direction.EAST) break;
                         }
                         // Edge case
-                        else if (offsetShape != RailShape.EAST_WEST && offsetShape != RailShape.NORTH_SOUTH){
+                        else if (offsetShape != RailShape.EAST_WEST && offsetShape != RailShape.NORTH_SOUTH) {
                             break;
                         }
 
@@ -235,7 +221,7 @@ public class MiscellaneousEvents {
                         boolean canGoDown = false;
                         RailShape offsetShape = null;
                         if (stateBelow.getBlock() instanceof BaseRailBlock) {
-                            offsetShape = stateBelow.getValue(((BaseRailBlock)stateBelow.getBlock()).getShapeProperty());
+                            offsetShape = stateBelow.getValue(((BaseRailBlock) stateBelow.getBlock()).getShapeProperty());
                         }
 
                         if (offsetShape == null) break;
@@ -315,7 +301,7 @@ public class MiscellaneousEvents {
             default -> null;
         };
         if (state.getBlock() instanceof BaseRailBlock) {
-            state = state.setValue(((BaseRailBlock)state.getBlock()).getShapeProperty(), placedShape);
+            state = state.setValue(((BaseRailBlock) state.getBlock()).getShapeProperty(), placedShape);
         }
         if (state.canSurvive(level, position)) {
             SoundType soundtype = state.getSoundType(level, position, player);
@@ -348,10 +334,14 @@ public class MiscellaneousEvents {
                 level.gameEvent(explosion.getDirectSourceEntity(), GameEvent.BLOCK_CHANGE, pos);
                 level.playSound(null, pos, NMLSounds.TORCH_EXTINGUISH.get(), SoundSource.BLOCKS, 1.0F, 1.0F);
 
-                if (state.is(Blocks.TORCH)) level.setBlock(pos, NMLBlocks.EXTINGUISHED_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.WALL_TORCH)) level.setBlock(pos, NMLBlocks.EXTINGUISHED_WALL_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.SOUL_TORCH)) level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_TORCH.get().withPropertiesOf(state), 11);
-                if (state.is(Blocks.SOUL_WALL_TORCH)) level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_WALL_TORCH.get().withPropertiesOf(state), 11);
+                if (state.is(Blocks.TORCH))
+                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_TORCH.get().withPropertiesOf(state), 11);
+                if (state.is(Blocks.WALL_TORCH))
+                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_WALL_TORCH.get().withPropertiesOf(state), 11);
+                if (state.is(Blocks.SOUL_TORCH))
+                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_TORCH.get().withPropertiesOf(state), 11);
+                if (state.is(Blocks.SOUL_WALL_TORCH))
+                    level.setBlock(pos, NMLBlocks.EXTINGUISHED_SOUL_WALL_TORCH.get().withPropertiesOf(state), 11);
             }
 
             if (event.getExplosion().getDirectSourceEntity() instanceof ExplosiveEntity explosive && explosive.getOwner() instanceof ServerPlayer serverPlayer && state.is(Tags.Blocks.ORES))

--- a/src/main/java/com/farcr/nomansland/common/registry/NMLRegistries.java
+++ b/src/main/java/com/farcr/nomansland/common/registry/NMLRegistries.java
@@ -3,6 +3,7 @@ package com.farcr.nomansland.common.registry;
 import com.farcr.nomansland.NoMansLand;
 import com.farcr.nomansland.client.ambience.fogmodifiers.FogModifier;
 import com.farcr.nomansland.common.block.tap.TapInteraction;
+import com.farcr.nomansland.common.block.torches.ExtinguishableBlock;
 import com.farcr.nomansland.common.world.feature.decorator.BoulderDecoratorType;
 import com.farcr.nomansland.common.world.feature.decorator.FallenTreeDecoratorType;
 import com.farcr.nomansland.common.world.feature.decorator.PondDecoratorType;
@@ -24,4 +25,7 @@ public class NMLRegistries {
     public static final Registry<FogModifier> FOG_MODIFIERS = new RegistryBuilder<>(FOG_MODIFIER_TYPE_KEY).create();
 
     public static final ResourceKey<Registry<TapInteraction>> TAP_INTERACTION_KEY = ResourceKey.createRegistryKey(NoMansLand.location("tapping"));
+
+    public static final ResourceKey<Registry<ExtinguishableBlock>> EXTINGUISHABLE_BLOCKS_KEY = ResourceKey.createRegistryKey(NoMansLand.location("extinguishable_blocks"));
+    public static final Registry<ExtinguishableBlock> EXTINGUISHABLE_BLOCKS = new RegistryBuilder<>(EXTINGUISHABLE_BLOCKS_KEY).create();
 }

--- a/src/main/java/com/farcr/nomansland/common/registry/blocks/NMLExtinguishables.java
+++ b/src/main/java/com/farcr/nomansland/common/registry/blocks/NMLExtinguishables.java
@@ -1,0 +1,44 @@
+package com.farcr.nomansland.common.registry.blocks;
+
+import com.farcr.nomansland.NoMansLand;
+import com.farcr.nomansland.common.block.torches.ExtinguishableBlock;
+import com.farcr.nomansland.common.registry.NMLRegistries;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class NMLExtinguishables {
+
+    public static final DeferredRegister<ExtinguishableBlock> EXTINGUISHABLES = DeferredRegister.create(NMLRegistries.EXTINGUISHABLE_BLOCKS_KEY, NoMansLand.MODID);
+    private static boolean registered = false;
+
+    public static <B extends Block> DeferredHolder<ExtinguishableBlock, ExtinguishableBlock> register(String name, Holder<B> from, Holder<B> to) {
+        return EXTINGUISHABLES.register(name, () -> new ExtinguishableBlock(from.value(), to.value()));
+    }
+
+    static {
+        register();
+    }
+
+    public static void register() {
+        if (!registered) {
+            registered = true;
+
+            register("torch", Holder.direct(Blocks.TORCH), NMLBlocks.EXTINGUISHED_TORCH.getDelegate());
+            register("torch_wall", Holder.direct(Blocks.WALL_TORCH), NMLBlocks.EXTINGUISHED_WALL_TORCH.getDelegate());
+            register("soul_torch", Holder.direct(Blocks.SOUL_TORCH), NMLBlocks.EXTINGUISHED_SOUL_TORCH.getDelegate());
+            register("soul_wall_torch", Holder.direct(Blocks.SOUL_WALL_TORCH), NMLBlocks.EXTINGUISHED_SOUL_WALL_TORCH.getDelegate());
+
+            register("sconce_torch", NMLBlocks.SCONCE_TORCH.getDelegate(), NMLBlocks.EXTINGUISHED_SCONCE_TORCH.getDelegate());
+            register("sconce_wall_torch", NMLBlocks.SCONCE_WALL_TORCH.getDelegate(), NMLBlocks.EXTINGUISHED_SCONCE_WALL_TORCH.getDelegate());
+            register("soul_sconce_torch", NMLBlocks.SCONCE_SOUL_TORCH.getDelegate(), NMLBlocks.EXTINGUISHED_SCONCE_SOUL_TORCH.getDelegate());
+            register("soul_sconce_wall_torch", NMLBlocks.SCONCE_SOUL_WALL_TORCH.getDelegate(), NMLBlocks.EXTINGUISHED_SCONCE_SOUL_WALL_TORCH.getDelegate());
+        } else {
+            throw new IllegalStateException("Unable to register Extinguishables; Already registered!");
+        }
+    }
+}


### PR DESCRIPTION
Currently, torch extinguishing / lighting uses hard coded hashmaps and arrays to determine what the block should change too.

Specifically with lighting, only the block state is checked for the lit block state property, which causes issues with other mods that use that state for alternative purposes

This PR fixes those two issue, along with making the whole system more diagetic to use.

- Adds a static registry in NMLRegistries for Extinguishables
- Add Extinguishable record that holds the extinguished block, and lit block
- Changes extinguishing / lighting to be iteration based when useOnBlock is called.
- Changes onExplosion to iterate through extinguishables