### PR TITLE
Add compatibility with Snow Real Magic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,7 @@ dependencies {
     compileOnly "maven.modrinth:glitchcore:8wmCpbQ2"
     compileOnly "maven.modrinth:supplementaries:neoforge_1.21-3.0.43-beta"
     compileOnly "maven.modrinth:vanity-core:5.0.2"
+    compileOnly "maven.modrinth:snow-real-magic:12.1.2+neoforge"
 
     compileOnly "mezz.jei:jei-$minecraft_version-common-api:$jei_version"
     compileOnly "mezz.jei:jei-$minecraft_version-neoforge-api:$jei_version"
@@ -156,7 +157,7 @@ dependencies {
 //    localRuntime "maven.modrinth:xaeros-world-map:1.38.9_NeoForge_1.21"
     localRuntime "maven.modrinth:appleskin:3.0.5+mc1.21"
     localRuntime "maven.modrinth:worldedit:7.3.6"
-    localRuntime "maven.modrinth:sodium:mc1.21.1-0.6.9-neoforge"
+    localRuntime "maven.modrinth:sodium:mc1.21.1-0.6.13-neoforge"
     localRuntime "me.djtheredstoner:DevAuth-neoforge:1.2.1"
     //localRuntime "maven.modrinth:cyanide:v4LiMGGH"
 }

--- a/src/main/java/com/farcr/nomansland/common/block/FrostedGrassBlock.java
+++ b/src/main/java/com/farcr/nomansland/common/block/FrostedGrassBlock.java
@@ -1,6 +1,7 @@
 package com.farcr.nomansland.common.block;
 
 import com.farcr.nomansland.NMLConfig;
+import com.farcr.nomansland.common.integration.Mods;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
@@ -40,7 +41,7 @@ public class FrostedGrassBlock extends BushBlock implements BonemealableBlock {
 
     @Override
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
-        if (player.getMainHandItem().is(Blocks.SNOW.asItem()) && !state.getValue(SNOWLOGGED) && NMLConfig.GRASS_FROSTING.get()) {
+        if (player.getMainHandItem().is(Blocks.SNOW.asItem()) && !state.getValue(SNOWLOGGED) && NMLConfig.GRASS_FROSTING.get() && !Mods.SNOWREALMAGIC.isLoaded()) {
             level.setBlockAndUpdate(pos, state.setValue(SNOWLOGGED, true));
             stack.consume(1, player);
             level.playSound(player, pos, SoundEvents.SNOW_PLACE, SoundSource.PLAYERS, 1.0F, (level.random.nextFloat() - level.random.nextFloat()) * 0.6F + 1.2F);

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -5,6 +5,7 @@ import com.farcr.nomansland.NoMansLand;
 import com.farcr.nomansland.common.block.torches.ExtinguishableBlock;
 import com.farcr.nomansland.common.entity.ai.EnemyAttackGoal;
 import com.farcr.nomansland.common.entity.bombs.Explosive;
+import com.farcr.nomansland.common.integration.Mods;
 import com.farcr.nomansland.common.registry.NMLCriteriaTriggers;
 import com.farcr.nomansland.common.registry.NMLRegistries;
 import com.farcr.nomansland.common.registry.NMLSounds;
@@ -122,7 +123,7 @@ public class MiscellaneousEvents {
         }
 
         // Grass Frosting
-        if (stack.is(Blocks.SNOW.asItem()) && !player.isSpectator() && state.is(Blocks.SHORT_GRASS)) {
+        if (stack.is(Blocks.SNOW.asItem()) && !player.isSpectator() && state.is(Blocks.SHORT_GRASS) && !Mods.SNOWREALMAGIC.isLoaded()) {
             level.setBlockAndUpdate(pos, NMLBlocks.FROSTED_GRASS.get().defaultBlockState().setValue(SNOWLOGGED, true));
             stack.consume(1, player);
             level.playSound(player, pos, SoundEvents.SNOW_PLACE, SoundSource.PLAYERS, 1, (level.random.nextFloat() - level.random.nextFloat()) * 0.6F + 1.2F);

--- a/src/main/java/com/farcr/nomansland/common/integration/Mods.java
+++ b/src/main/java/com/farcr/nomansland/common/integration/Mods.java
@@ -14,7 +14,8 @@ public enum Mods {
     BOATLOAD,
     BLUEPRINT,
     NIRVANA,
-    EVERYCOMP;
+    EVERYCOMP,
+    SNOWREALMAGIC;
 
     private final String id;
 

--- a/src/main/java/com/farcr/nomansland/common/mixin/BiomeMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/BiomeMixin.java
@@ -1,6 +1,7 @@
 package com.farcr.nomansland.common.mixin;
 
 import com.farcr.nomansland.NMLConfig;
+import com.farcr.nomansland.common.integration.Mods;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
 import com.moulberry.mixinconstraints.annotations.IfModAbsent;
 import net.minecraft.core.BlockPos;
@@ -22,6 +23,7 @@ public class BiomeMixin {
     @Inject(method = "shouldSnow", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/LevelReader;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;", shift = At.Shift.AFTER), cancellable = true)
     private void snowOnShortGrass(LevelReader level, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         if(!NMLConfig.GRASS_FROSTING.get()) return;
+        if(Mods.SNOWREALMAGIC.isLoaded()) return; // We can't use a second IfModAbsent because mixinconstraints 1.0.7 is bugged and other dependencies are incompatible with the newer version.
 
         BlockState blockstate = level.getBlockState(pos);
         if (blockstate.is(Blocks.SHORT_GRASS) || blockstate.is(NMLBlocks.FROSTED_GRASS.get()) && !blockstate.getValue(SNOWLOGGED)) {

--- a/src/main/java/com/farcr/nomansland/common/mixin/BiomeMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/BiomeMixin.java
@@ -21,9 +21,10 @@ public class BiomeMixin {
 
     @Inject(method = "shouldSnow", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/LevelReader;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;", shift = At.Shift.AFTER), cancellable = true)
     private void snowOnShortGrass(LevelReader level, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        BlockState blockstate = level.getBlockState(pos);
+        if(!NMLConfig.GRASS_FROSTING.get()) return;
 
-        if (blockstate.is(Blocks.SHORT_GRASS) || (blockstate.is(NMLBlocks.FROSTED_GRASS.get()) && !blockstate.getValue(SNOWLOGGED)) && NMLConfig.GRASS_FROSTING.get()) {
+        BlockState blockstate = level.getBlockState(pos);
+        if (blockstate.is(Blocks.SHORT_GRASS) || blockstate.is(NMLBlocks.FROSTED_GRASS.get()) && !blockstate.getValue(SNOWLOGGED)) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/com/farcr/nomansland/common/mixin/ServerLevelMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/ServerLevelMixin.java
@@ -1,6 +1,7 @@
 package com.farcr.nomansland.common.mixin;
 
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.moulberry.mixinconstraints.annotations.IfModAbsent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Blocks;
@@ -16,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import static com.farcr.nomansland.common.block.FrostedGrassBlock.SNOWLOGGED;
 import static net.minecraft.world.level.block.SnowyDirtBlock.SNOWY;
 
+@IfModAbsent("snowrealmagic")
 @Mixin(value = ServerLevel.class)
 public abstract class ServerLevelMixin {
 

--- a/src/main/java/com/farcr/nomansland/common/mixin/SnowAndFreezeFeatureMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/SnowAndFreezeFeatureMixin.java
@@ -1,6 +1,7 @@
 package com.farcr.nomansland.common.mixin;
 
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.moulberry.mixinconstraints.annotations.IfModAbsent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.WorldGenLevel;
@@ -19,6 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import static com.farcr.nomansland.common.block.FrostedGrassBlock.SNOWLOGGED;
 
+@IfModAbsent("snowrealmagic")
 @Mixin(SnowAndFreezeFeature.class)
 public class SnowAndFreezeFeatureMixin {
 
@@ -44,7 +46,10 @@ public class SnowAndFreezeFeatureMixin {
                 if (biome.shouldSnow(worldgenlevel, mutableblockpos)) {
                     if (worldgenlevel.getBlockState(mutableblockpos).is(NMLBlocks.FROSTED_GRASS.block())) {
                         worldgenlevel.setBlock(mutableblockpos, NMLBlocks.FROSTED_GRASS.get().defaultBlockState().setValue(SNOWLOGGED, true), 2);
-                    } else worldgenlevel.setBlock(mutableblockpos, Blocks.SNOW.defaultBlockState(), 2);                    BlockState blockstate = worldgenlevel.getBlockState(mutableblockpos1);
+                    } else {
+                        worldgenlevel.setBlock(mutableblockpos, Blocks.SNOW.defaultBlockState(), 2);
+                    }
+                    BlockState blockstate = worldgenlevel.getBlockState(mutableblockpos1);
                     if (blockstate.hasProperty(SnowyDirtBlock.SNOWY)) {
                         worldgenlevel.setBlock(mutableblockpos1, blockstate.setValue(SnowyDirtBlock.SNOWY, true), 2);
                     }

--- a/src/main/java/com/farcr/nomansland/common/mixin/integration/RandomUpdateHandlerMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/integration/RandomUpdateHandlerMixin.java
@@ -3,6 +3,7 @@ package com.farcr.nomansland.common.mixin.integration;
 import com.farcr.nomansland.common.block.FrostedGrassBlock;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.moulberry.mixinconstraints.annotations.IfModAbsent;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -21,6 +22,7 @@ import sereneseasons.season.RandomUpdateHandler;
 import sereneseasons.season.SeasonHooks;
 
 @IfModLoaded("sereneseasons")
+@IfModAbsent("snowrealmagic")
 @Mixin(RandomUpdateHandler.class)
 public class RandomUpdateHandlerMixin {
 

--- a/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
@@ -22,8 +22,10 @@ public class SeasonHooksMixin {
 
     @Inject(method = "shouldSnowHook", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/LevelReader;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;", shift = At.Shift.AFTER), cancellable = true)
     private static void snowOnShortGrass(Biome biome, LevelReader levelReader, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if(!NMLConfig.GRASS_FROSTING.get()) return;
+
         BlockState blockstate = levelReader.getBlockState(pos);
-        if (blockstate.is(Blocks.SHORT_GRASS) || (blockstate.is(NMLBlocks.FROSTED_GRASS.get()) && !blockstate.getValue(SNOWLOGGED)) && NMLConfig.GRASS_FROSTING.get()) {
+        if (blockstate.is(Blocks.SHORT_GRASS) || blockstate.is(NMLBlocks.FROSTED_GRASS.get()) && !blockstate.getValue(SNOWLOGGED)) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
@@ -2,6 +2,7 @@ package com.farcr.nomansland.common.mixin.integration;
 
 import com.farcr.nomansland.NMLConfig;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
+import com.moulberry.mixinconstraints.annotations.IfModAbsent;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
@@ -17,6 +18,7 @@ import sereneseasons.season.SeasonHooks;
 import static com.farcr.nomansland.common.block.FrostedGrassBlock.SNOWLOGGED;
 
 @IfModLoaded("sereneseasons")
+@IfModAbsent("snowrealmagic")
 @Mixin(SeasonHooks.class)
 public class SeasonHooksMixin {
 

--- a/src/main/resources/data/c/tags/block/grass.json
+++ b/src/main/resources/data/c/tags/block/grass.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "nomansland:dried_grass",
+    "nomansland:fiddlehead",
+    "nomansland:frosted_grass",
+    "nomansland:grass_sprouts",
+    "nomansland:oat_grass",
+    "nomansland:short_beachgrass",
+    "nomansland:tall_beachgrass"
+  ]
+}

--- a/src/main/resources/data/c/tags/block/mushrooms.json
+++ b/src/main/resources/data/c/tags/block/mushrooms.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "nomansland:mycelium_sprouts",
+    "nomansland:mycelium_growths"
+  ]
+}

--- a/src/main/resources/data/snowrealmagic/tags/block/containables.json
+++ b/src/main/resources/data/snowrealmagic/tags/block/containables.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "values": [
+    "nomansland:aconite",
+    "nomansland:autumn_crocus",
+    "nomansland:barrel_cactus",
+    "nomansland:blue_flowerbed",
+    "nomansland:blue_lupine",
+    "nomansland:cattail",
+    "nomansland:cave_weeds",
+    "nomansland:clover_patch",
+    "nomansland:frosted_grass",
+    "nomansland:ground_ivy",
+    "nomansland:lavender_bush",
+    "nomansland:mycelium_sprouts",
+    "nomansland:pebbles",
+    "nomansland:pink_lupine",
+    "nomansland:rafflesia",
+    "nomansland:red_flowerbed",
+    "nomansland:red_lupine",
+    "nomansland:reeds",
+    "nomansland:rose_vines",
+    "nomansland:seashells",
+    "nomansland:starflower",
+    "nomansland:succulent",
+    "nomansland:thistle",
+    "nomansland:violet_flowerbed",
+    "nomansland:white_flowerbed",
+    "nomansland:wild_mint",
+    "nomansland:yellow_flowerbed",
+    "nomansland:yellow_lupine"
+  ]
+}

--- a/src/main/resources/data/snowrealmagic/tags/block/offset_y.json
+++ b/src/main/resources/data/snowrealmagic/tags/block/offset_y.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "nomansland:pebbles",
+    "nomansland:seashells"
+  ]
+}

--- a/src/main/resources/data/snowrealmagic/tags/block/plants.json
+++ b/src/main/resources/data/snowrealmagic/tags/block/plants.json
@@ -1,0 +1,31 @@
+{
+  "replace": false,
+  "values": [
+    "nomansland:aconite",
+    "nomansland:autumn_crocus",
+    "nomansland:barrel_cactus",
+    "nomansland:blue_flowerbed",
+    "nomansland:blue_lupine",
+    "nomansland:cattail",
+    "nomansland:cave_weeds",
+    "nomansland:clover_patch",
+    "nomansland:frosted_grass",
+    "nomansland:ground_ivy",
+    "nomansland:lavender_bush",
+    "nomansland:mycelium_sprouts",
+    "nomansland:pink_lupine",
+    "nomansland:rafflesia",
+    "nomansland:red_flowerbed",
+    "nomansland:red_lupine",
+    "nomansland:reeds",
+    "nomansland:rose_vines",
+    "nomansland:starflower",
+    "nomansland:succulent",
+    "nomansland:thistle",
+    "nomansland:violet_flowerbed",
+    "nomansland:white_flowerbed",
+    "nomansland:wild_mint",
+    "nomansland:yellow_flowerbed",
+    "nomansland:yellow_lupine"
+  ]
+}


### PR DESCRIPTION
Adds compatibility with Snow! Real Magic! by disabling NML's snowlogging and snowfall features when SRM is loaded. Additionally, tags NML's blocks for SRM's snowlogging.