### PR TITLE
Allow water surface plants on ice

### DIFF
--- a/src/main/java/com/farcr/nomansland/common/block/WaterSurfacePlant.java
+++ b/src/main/java/com/farcr/nomansland/common/block/WaterSurfacePlant.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.BushBlock;
+import net.minecraft.world.level.block.IceBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
@@ -38,7 +39,7 @@ public class WaterSurfacePlant extends BushBlock implements BonemealableBlock {
     protected boolean mayPlaceOn(BlockState state, BlockGetter level, BlockPos pos) {
         FluidState fluidState = level.getFluidState(pos);
         FluidState fluidStateAbove = level.getFluidState(pos.above());
-        return fluidState.getType() == Fluids.WATER && fluidStateAbove.getType() == Fluids.EMPTY;
+        return (fluidState.getType() == Fluids.WATER || state.getBlock() instanceof IceBlock) && fluidStateAbove.getType() == Fluids.EMPTY;
     }
 
     @Override


### PR DESCRIPTION
This matches the behavior of vanilla lily pads, which is particularly useful when other mods (like Immersive Snow) freeze water as seasons change.