### PR TITLE
Add Sable support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ group = mod_group_id
 
 repositories {
     mavenLocal()
+    maven {
+        name = "RyanHCode Maven"
+        url = "https://maven.ryanhcode.dev/releases"
+    }
 }
 
 base {
@@ -130,6 +134,11 @@ dependencies {
                         module: "slf4j-api"
     })
 
+    jarJar(api("dev.ryanhcode.sable-companion:sable-companion-${project.minecraft_version}:${project.sable_companion_version_range}")) {
+        version {
+            prefer project.sable_companion_version
+        }
+    }
 
 //MAKE SURE THESE ARE ALL "IMPLEMENTATION" WHEN RUNNING DATA! OTHERWISE DATA WILL BREAK!
     implementation "maven.modrinth:farmers-delight:1.21.1-1.2.7"

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,5 @@ bt_version_range=[3.0.9,)
 # Mixed Litter
 ml_version=1.0.3
 ml_version_range=[1.0.1,)
+sable_companion_version=1.1.0
+sable_companion_version_range=[1.1.0,)

--- a/src/main/java/com/farcr/nomansland/common/entity/bombs/Explosive.java
+++ b/src/main/java/com/farcr/nomansland/common/entity/bombs/Explosive.java
@@ -3,6 +3,8 @@ package com.farcr.nomansland.common.entity.bombs;
 import com.farcr.nomansland.NMLConfig;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
 import com.farcr.nomansland.common.registry.entities.NMLEntities;
+import dev.ryanhcode.sable.companion.SableCompanion;
+import dev.ryanhcode.sable.companion.SubLevelAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
@@ -113,7 +115,15 @@ public class Explosive extends ThrowableBombEntity {
         super.onHitBlock(result);
         Vec3 pos = position();
         Vec3 resultPos = result.getLocation();
-        Vec3 dir = pos.vectorTo(resultPos).normalize();
+        Vec3 dir;
+
+        SubLevelAccess subLevel = SableCompanion.INSTANCE.getContaining(this.level(), result.getBlockPos());
+        if (subLevel != null) {
+            dir = subLevel.logicalPose().transformPositionInverse(pos).vectorTo(resultPos).normalize();
+        } else {
+            dir = pos.vectorTo(resultPos).normalize();
+        }
+
         setDeltaMovement(Vec3.ZERO);
         setPos(new Vec3(resultPos.x - dir.x * getBbWidth() * 0.01, resultPos.y - dir.y * getBbHeight() * 0.01, resultPos.z - dir.z * getBbWidth() * 0.01));
         setNoGravity(true);


### PR DESCRIPTION
Sable Companion is a ~30kb jar that abstracts away position. It essentially allows other mods to understand the basic concept of sub-levels without needing to depend on all of Sable.