### PR TITLE
Add conditional mixin for Ecliptic Seasons mod (Serene Seasons API Stub)

### DIFF
--- a/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/integration/SeasonHooksMixin.java
@@ -19,6 +19,7 @@ import static com.farcr.nomansland.common.block.FrostedGrassBlock.SNOWLOGGED;
 
 @IfModLoaded("sereneseasons")
 @IfModAbsent("snowrealmagic")
+@IfModAbsent("eclipticseasons")
 @Mixin(SeasonHooks.class)
 public class SeasonHooksMixin {
 


### PR DESCRIPTION
Hello, I am the author of the **Ecliptic Seasons** mod. Some players who use both of our mods reported to me that **Nomansland** crashes when used together with **Serene Seasons API Stub (Ecliptic Seasons Bridge)**. After investigating the issue, I found that your mod mixes into **Serene Seasons**, while our bridge only mimics the Serene Seasons API interfaces rather than implementing the same internal logic.

In our mod we already provide our own **snowy grass–type design**, so grass will not appear visually inconsistent when covered by snow. If you are interested, we would also be open to discussing proper compatibility between the two projects.

However, since our mod does not have a particularly large download base, my intention here is simply to submit a small **PR** to improve compatibility with the **Serene Seasons API Stub**.

CurseForge page:
[https://legacy.curseforge.com/minecraft/mc-mods/serene-seasons-api-stub-ecliptic-seasons-bridge](https://legacy.curseforge.com/minecraft/mc-mods/serene-seasons-api-stub-ecliptic-seasons-bridge)

This is a bridge mod intended to connect **Serene Seasons compatibility code** with **Ecliptic Seasons**. Many mod developers are not familiar with our mod, and it is not feasible for us to individually implement compatibility patches for every mod.
