### PR TITLE
Sable Compatibility for Warding Effigies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,23 @@ repositories {
             includeGroup "com.tterrag.registrate"
         }
     }
+    maven {
+        name = "Illusive Soulworks maven"
+        url = "https://maven.theillusivec4.top/"
+    }
+    maven {
+        name = "RyanHCode Maven"
+        url = "https://maven.ryanhcode.dev/releases"
+    }
+    maven {
+        name = "SquidDev Maven"
+        url = "https://maven.squiddev.cc"
+        content {
+            includeGroup("cc.tweaked")
+        }
+    }
+    maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+    maven { url = "https://maven.ithundxr.dev/snapshots" } // Registrate
     maven { url "https://maven.blamejared.com/" }
     maven { url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
     maven { url 'https://maven.terraformersmc.com/' }
@@ -135,10 +152,21 @@ dependencies {
                         module: "slf4j-api"
     })
 
-    jarJar(api("dev.ryanhcode.sable-companion:sable-companion-${project.minecraft_version}:${project.sable_companion_version_range}")) {
+    jarJar(api("dev.ryanhcode.sable-companion:sable-companion-common-${project.minecraft_version}:${project.sable_companion_version}")) {
         version {
             prefer project.sable_companion_version
         }
+    }
+
+    compileOnly("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
+    if(project.create_enabled) {
+        runtimeOnly("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
+        runtimeOnly("net.createmod.ponder:ponder-neoforge:${ponder_version}+mc${minecraft_version}")
+        runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
+    }
+
+    if(project.create_simulated_enabled) {
+        runtimeOnly("dev.simulated_team.simulated:simulated-neoforge-${minecraft_version}:${simulated_version}")
     }
 
 //MAKE SURE THESE ARE ALL "IMPLEMENTATION" WHEN RUNNING DATA! OTHERWISE DATA WILL BREAK!
@@ -155,7 +183,6 @@ dependencies {
     compileOnly "maven.modrinth:scaffolding-drops-nearby:1.21.1-3.4-fabric+forge+neo"
     compileOnly "maven.modrinth:collective:1.21.1-8.3-fabric+forge+neo"
     implementation "maven.modrinth:brewin-and-chewin:4.2.0+1.21.1-neoforge"
-    compileOnly "maven.modrinth:create:1.21.1-6.0.4"
     compileOnly "maven.modrinth:serene-seasons:SPj5bJoM"
     compileOnly "maven.modrinth:glitchcore:8wmCpbQ2"
     compileOnly "maven.modrinth:supplementaries:1.21-3.5.27-neoforge"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ parchment_mappings_version=2024.11.17
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1]
 # Neoforge
-neo_version=21.1.209
+neo_version=21.1.227
 neo_version_range=[21.1.207,)
 loader_version_range=[4,)
 # JEI
@@ -33,5 +33,16 @@ bt_version_range=[3.0.9,)
 # Mixed Litter
 ml_version=1.1.0
 ml_version_range=[1.0.1,)
-sable_companion_version=1.1.0
+
+
+# Create
+create_enabled=false
+create_version = 6.0.9-215
+ponder_version = 1.0.81
+flywheel_version = 1.0.6
+registrate_version = MC1.21-1.3.0+67
+# Sable
+sable_companion_version=1.4.2
 sable_companion_version_range=[1.1.0,)
+create_simulated_enabled=false
+simulated_version = 1.0.3

--- a/src/main/java/com/farcr/nomansland/common/block/WardingEffigyBlock.java
+++ b/src/main/java/com/farcr/nomansland/common/block/WardingEffigyBlock.java
@@ -137,8 +137,7 @@ public class WardingEffigyBlock extends BaseEntityBlock {
     @Override
     protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
         if (level instanceof ServerLevel serverLevel) {
-            WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
-                    WardedSpacesData::new, WardedSpacesData::create), WardedSpacesData.NAME);
+            WardedSpacesData wardedSpacesData = WardedSpacesData.get(serverLevel);
 
             wardedSpacesData.addEffigy(pos, getRange(state));
         }

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -392,7 +392,7 @@ public class MiscellaneousEvents {
             WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
                     () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
 
-            event.setSpawnCancelled(wardedSpacesData.isWarded(event.getEntity().blockPosition()));
+            event.setSpawnCancelled(wardedSpacesData.isWarded(serverLevel, event.getEntity().blockPosition()));
         }
 
         if (event.getLevel() instanceof ServerLevel serverLevel

--- a/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/MiscellaneousEvents.java
@@ -389,8 +389,7 @@ public class MiscellaneousEvents {
         if (event.getLevel() instanceof ServerLevel serverLevel
                 && event.getSpawnType() == MobSpawnType.NATURAL
                 && event.getEntity() instanceof Monster) {
-            WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
-                    () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
+            WardedSpacesData wardedSpacesData = WardedSpacesData.get(serverLevel);
 
             event.setSpawnCancelled(wardedSpacesData.isWarded(serverLevel, event.getEntity().blockPosition()));
         }

--- a/src/main/java/com/farcr/nomansland/common/mixin/PatrolSpawnerMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/PatrolSpawnerMixin.java
@@ -17,7 +17,7 @@ public class PatrolSpawnerMixin {
         WardedSpacesData wardedSpacesData = instance.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
                 WardedSpacesData::new, WardedSpacesData::create), WardedSpacesData.NAME);
 
-        if (wardedSpacesData.isWarded(pos)) {
+        if (wardedSpacesData.isWarded(instance, pos)) {
             return true;
         } else return original.call(instance, pos, sections);
     }

--- a/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
@@ -28,8 +28,8 @@ public class RandomStrollGoalMixin {
             WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
                     () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
 
-            if (wardedSpacesData.isWarded(mob.blockPosition())) {
-                BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.blockPosition()).orElse(null);
+            if (wardedSpacesData.isWarded(mob.level(), mob.blockPosition())) {
+                BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.level(), mob.blockPosition()).orElse(null);
                 if (effigyPos != null) {
                     int effigyRange = wardedSpacesData.ranges.get(wardedSpacesData.positions.indexOf(effigyPos));
 

--- a/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
@@ -25,8 +25,7 @@ public class RandomStrollGoalMixin {
     @Inject(method = "getPosition", at = @At("HEAD"), cancellable = true)
     private void getPosition(CallbackInfoReturnable<Vec3> cir) {
         if (mob instanceof Monster && mob.level() instanceof ServerLevel serverLevel) {
-            WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
-                    () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
+            WardedSpacesData wardedSpacesData = WardedSpacesData.get(serverLevel);
 
             if (wardedSpacesData.isWarded(mob.level(), mob.blockPosition())) {
                 BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.level(), mob.blockPosition()).orElse(null);

--- a/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/RandomStrollGoalMixin.java
@@ -7,7 +7,6 @@ import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
 import net.minecraft.world.entity.ai.util.LandRandomPos;
 import net.minecraft.world.entity.monster.Monster;
-import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,8 +14,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.ArrayList;
 
 @Mixin(RandomStrollGoal.class)
 public class RandomStrollGoalMixin {

--- a/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
@@ -23,8 +23,8 @@ public class WaterAvoidingRandomStrollGoalMixin extends RandomStrollGoalMixin {
             WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
                     () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
 
-            if (wardedSpacesData.isWarded(mob.blockPosition())) {
-                BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.blockPosition()).orElse(null);
+            if (wardedSpacesData.isWarded(mob.level(), mob.blockPosition())) {
+                BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.level(), mob.blockPosition()).orElse(null);
                 if (effigyPos != null) {
                     int effigyRange = wardedSpacesData.ranges.get(wardedSpacesData.positions.indexOf(effigyPos));
 

--- a/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
@@ -20,8 +20,7 @@ public class WaterAvoidingRandomStrollGoalMixin extends RandomStrollGoalMixin {
     @Inject(method = "getPosition", at = @At("HEAD"), cancellable = true)
     private void getPosition(CallbackInfoReturnable<Vec3> cir) {
         if (mob instanceof Monster && mob.level() instanceof ServerLevel serverLevel) {
-            WardedSpacesData wardedSpacesData = serverLevel.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
-                    () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
+            WardedSpacesData wardedSpacesData = WardedSpacesData.get(serverLevel);
 
             if (wardedSpacesData.isWarded(mob.level(), mob.blockPosition())) {
                 BlockPos effigyPos = wardedSpacesData.getAffectingEffigyAt(mob.level(), mob.blockPosition()).orElse(null);

--- a/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
+++ b/src/main/java/com/farcr/nomansland/common/mixin/WaterAvoidingRandomStrollGoalMixin.java
@@ -6,14 +6,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.goal.WaterAvoidingRandomStrollGoal;
 import net.minecraft.world.entity.ai.util.LandRandomPos;
 import net.minecraft.world.entity.monster.Monster;
-import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.ArrayList;
 
 @Mixin(WaterAvoidingRandomStrollGoal.class)
 public class WaterAvoidingRandomStrollGoalMixin extends RandomStrollGoalMixin {

--- a/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
+++ b/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
@@ -5,6 +5,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Position;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
@@ -38,6 +39,11 @@ public class WardedSpacesData extends SavedData {
         Arrays.stream(tag.getIntArray("ranges")).forEachOrdered(ranges::add);
 
         return new WardedSpacesData(positions, ranges);
+    }
+
+    public static WardedSpacesData get(ServerLevel level) {
+        return level.getDataStorage().computeIfAbsent(new SavedData.Factory<>(
+                () -> new WardedSpacesData(new ArrayList<>(), new ArrayList<>()), WardedSpacesData::create), WardedSpacesData.NAME);
     }
 
     @Override

--- a/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
+++ b/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
@@ -3,17 +3,14 @@ package com.farcr.nomansland.common.world.saved_data;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.Position;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
-import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 public class WardedSpacesData extends SavedData {

--- a/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
+++ b/src/main/java/com/farcr/nomansland/common/world/saved_data/WardedSpacesData.java
@@ -1,13 +1,18 @@
 package com.farcr.nomansland.common.world.saved_data;
 
+import dev.ryanhcode.sable.companion.SableCompanion;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Position;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 public class WardedSpacesData extends SavedData {
@@ -62,11 +67,13 @@ public class WardedSpacesData extends SavedData {
         }
     }
 
-    public boolean isWarded(BlockPos pos) {
+    public boolean isWarded(Level level, BlockPos pos) {
         if (positions.contains(pos)) return true;
 
         for (BlockPos wardedPos : positions) {
-            if (wardedPos.distSqr(pos) <= Mth.square(ranges.get(positions.indexOf(wardedPos)))) {
+            double dist = SableCompanion.INSTANCE.distanceSquaredWithSubLevels(level, pos.getCenter(), wardedPos.getCenter());
+
+            if (dist <= Mth.square(ranges.get(positions.indexOf(wardedPos)))) {
                 return true;
             }
         }
@@ -74,15 +81,20 @@ public class WardedSpacesData extends SavedData {
         return false;
     }
 
-    public Optional<BlockPos> getAffectingEffigyAt(BlockPos pos) {
+    public Optional<BlockPos> getAffectingEffigyAt(Level level, BlockPos pos) {
         if (positions.contains(pos)) return Optional.of(pos);
 
         BlockPos closestEffigy = null;
+        double closest = Double.MAX_VALUE;
         for (BlockPos wardedPos : positions) {
-            if (wardedPos.distSqr(pos) <= Mth.square(ranges.get(positions.indexOf(wardedPos)))) {
+            double dist = SableCompanion.INSTANCE.distanceSquaredWithSubLevels(level, pos.getCenter(), wardedPos.getCenter());
+
+            if (dist <= Mth.square(ranges.get(positions.indexOf(wardedPos)))) {
                 if (closestEffigy == null) closestEffigy = wardedPos;
-                else if (wardedPos.distSqr(pos) < closestEffigy.distSqr(pos))
+                else if (dist < closest) {
                     closestEffigy = wardedPos;
+                    closest = dist;
+                }
             }
         }
 


### PR DESCRIPTION
This PR uses Sable Companion to take the positions of warding effigies on Sable sublevels into account when warding away mobs.

It also changes `build.gradle` and `gradle.properties` to allow Create and Create Simulated to (optionally) be used in the development environment. 

Finally, it also cuts down on a long, repeated line of code when fetching the `ServerLevel`'s `WardedSpacesData`.