### PR TITLE
Add config to disable PathMakingEvents, add back tag checks to fix #255

### DIFF
--- a/src/main/java/com/farcr/nomansland/NMLConfig.java
+++ b/src/main/java/com/farcr/nomansland/NMLConfig.java
@@ -26,6 +26,7 @@ public class NMLConfig {
     public static ModConfigSpec.BooleanValue TRAMPLING;
     public static ModConfigSpec.BooleanValue TORCH_EXTINGUISHING;
     public static ModConfigSpec.BooleanValue GRASS_FROSTING;
+    public static ModConfigSpec.BooleanValue PATH_TWEAKS;
     public static final String CATEGORY_BIOMES = "biomes";
     public static ModConfigSpec.BooleanValue BIOMES;
     public static ModConfigSpec.BooleanValue CAVES_BIOMES;
@@ -113,6 +114,9 @@ public class NMLConfig {
         COMMON_BUILDER.comment("For configuring the mob remodels, go to the mixed litter startup config!");
 
         COMMON_BUILDER.push(CATEGORY_OVERRIDES);
+        PATH_TWEAKS = COMMON_BUILDER
+                .comment("If using a hoe/shovel on plants tills/paths the blocks below it")
+                .define("farmlandPathTweaks", true);
         GRASS_SPREADS = COMMON_BUILDER
                 .comment("If grass or mycelium spread to nearby dirt.")
                 .define("grassSpreads", true);

--- a/src/main/java/com/farcr/nomansland/common/event/PathMakingEvents.java
+++ b/src/main/java/com/farcr/nomansland/common/event/PathMakingEvents.java
@@ -1,6 +1,8 @@
 package com.farcr.nomansland.common.event;
 
+import com.farcr.nomansland.NMLConfig;
 import com.farcr.nomansland.NoMansLand;
+import com.farcr.nomansland.common.registry.NMLTags;
 import com.farcr.nomansland.common.registry.blocks.NMLBlocks;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
@@ -10,6 +12,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -28,16 +31,36 @@ import static net.minecraft.world.level.block.SnowyDirtBlock.SNOWY;
 @EventBusSubscriber(modid = NoMansLand.MODID)
 public class PathMakingEvents {
 
+    /**
+     * Verifies that the Path/Farmland Tweak can proceed. In order to proceed:
+     *  - The player may not be a spectator
+     *  - The stack needs to be nomansland:makes_paths or nomansland:makes_farmland
+     *  - The item needs to have the till or flatten ability
+     * @param event The original RightClickBlock event
+     * @return True/False based on the above
+     */
+    private static boolean canContinue(PlayerInteractEvent.RightClickBlock event) {
+        ItemStack stack = event.getItemStack();
+        Item item = stack.getItem();
+
+        if (event.getEntity().isSpectator()) return false;
+
+        if (!(stack.is(NMLTags.MAKES_PATHS) || stack.is(NMLTags.MAKES_FARMLAND))) return false;
+
+        return item.canPerformAction(stack, ItemAbilities.HOE_TILL) || item.canPerformAction(stack, ItemAbilities.SHOVEL_FLATTEN);
+    }
+
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (!NMLConfig.PATH_TWEAKS.get() || !canContinue(event)) return;
+
         Level level = event.getLevel();
         BlockPos pos = event.getPos();
         BlockState state = level.getBlockState(pos);
         Player player = event.getEntity();
         ItemStack stack = event.getItemStack();
 
-
-        if ((stack.getItem().canPerformAction(stack, ItemAbilities.HOE_TILL) || stack.getItem().canPerformAction(stack, ItemAbilities.SHOVEL_FLATTEN)) && !player.isSpectator() && state.canBeReplaced()) {
+        if (state.canBeReplaced()) {
             pos = pos.below();
             state = level.getBlockState(pos);
         }
@@ -84,7 +107,8 @@ public class PathMakingEvents {
                         Map.entry(NMLBlocks.SILT.get(), NMLBlocks.SILT_PATH)
                 ).get(state.getBlock()).value().defaultBlockState();
 
-                if ((state.is(Blocks.DIRT) || state.is(Blocks.COARSE_DIRT) || state.is(Blocks.ROOTED_DIRT) || state.is(Blocks.GRASS_BLOCK)) && level.getBlockState(pos.above()).is(Blocks.SNOW)) level.setBlockAndUpdate(pos, NMLBlocks.SNOWY_GRASS_PATH.get().defaultBlockState());
+                if ((state.is(Blocks.DIRT) || state.is(Blocks.COARSE_DIRT) || state.is(Blocks.ROOTED_DIRT) || state.is(Blocks.GRASS_BLOCK)) && level.getBlockState(pos.above()).is(Blocks.SNOW))
+                    level.setBlockAndUpdate(pos, NMLBlocks.SNOWY_GRASS_PATH.get().defaultBlockState());
                 else level.setBlockAndUpdate(pos, pathState);
             }
 

--- a/src/main/java/com/farcr/nomansland/common/registry/NMLTags.java
+++ b/src/main/java/com/farcr/nomansland/common/registry/NMLTags.java
@@ -18,6 +18,8 @@ public class NMLTags {
     public static final TagKey<Item> TORTOISE_FOOD = createItemTag("tortoise_food");
     public static final TagKey<Item> MAKES_RESIN_OIL = createItemTag("makes_resin_oil");
     public static final TagKey<Item> INK_IMMUNE = createItemTag("ink_immune");
+    public static final TagKey<Item> MAKES_PATHS = createItemTag("makes_paths");
+    public static final TagKey<Item> MAKES_FARMLAND = createItemTag("makes_farmland");
 
     public static final SharedTag MAPLE_LOGS = createSharedTag("maple_logs");
     public static final SharedTag PINE_LOGS = createSharedTag("pine_logs");


### PR DESCRIPTION
This PR resolves #255 by adding a common config to functionally disable `PathMakingTweaks`, as well as a check against tags to determine if the tool can be used. 

Since the cases were getting a bit long, I added a new private static `canContinue` method which does all of the checks for against tool tags, abilities, player spectator state, and any more cases you choose to add in the future.

Fully tested in the dev environment with no issue.